### PR TITLE
Add compatibility with later ES 6 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Its current implementation is tested using the following stack:
 
 - Scala 2.12.7
 - Akka 2.5.21
-- Elasticsearch 6.5.3
+- Elasticsearch 6.8.6
 
 ## Usage
 

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.3
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.6
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu

--- a/src/main/scala/com/tradeshift/akka/persistence/elasticsearch/ElasticsearchClient.scala
+++ b/src/main/scala/com/tradeshift/akka/persistence/elasticsearch/ElasticsearchClient.scala
@@ -45,6 +45,7 @@ class ElasticsearchClient(implicit system: ActorSystem) extends StrictLogging {
     for {
       resp1 <- request(PUT,
         path = /(indexName),
+        query = Query("include_type_name" -> "true"),  // needed from ES 6.7+
         entity = HttpEntity(`application/json`, pretty(render(
           ("settings" -> settings) ~
           ("mappings" -> ("_doc" -> mappings))


### PR DESCRIPTION
Type mappings are deprecated in 7.0, and this required parameter was
added somewhere along ES 6.7.